### PR TITLE
v2: Upgrade to Claude 3.5 Haiku, OpenSearch 2.15, and Unreal Engine 5.4 with cost optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,19 @@ ___If you're looking for quick and easy step by step guide to get started, check
 
 ### Cost
 
-_You are responsible for the cost of the AWS services used while running this Guidance. As of January 2024, the cost for running this Guidance with the default settings in the `us-east-1` (N. Virginia) AWS Region is approximately $590.59 per month for processing 100 records._
+_You are responsible for the cost of the AWS services used while running this Guidance. As of November 2025, the cost for running this Guidance with the default settings in the `us-west-2` (Oregon) AWS Region is approximately $275 per month for processing 100 requests._
 
 For example, the following table shows a break-down of approximate costs _(per month)_ to process 100 requests, using an **Amazon OpenSearch Service** vector database for RAG:
 
 |     **Service**    | **Cost (per month)** |
 |:------------------:|:--------------------:|
-| OpenSearch Service | $586.65              |
+| OpenSearch Service | $270.00              |
 | SageMaker          | $1.43                |
 | S3                 | $0.67                |
 | CodeBuild          | $0.34                |
 | Secrets Manager    | $0.20                |
-| Bedrock            | $1.30                |
-|      **Total**     | **$590.59**           |
+| Bedrock            | $0.26                |
+|      **Total**     | **$272.90**          |
 
 
 ## Prerequisites
@@ -67,11 +67,11 @@ Before deploying the guidance code, ensure that the following required tools hav
 
 >__NOTE:__ The Guidance has been tested using AWS CDK version 2.178.2. If you wish to update the CDK application to later version, make sure to update the `requirements.txt`, and `cdk.json` files, in the root of the repository, with the updated version of the AWS CDK.
 
-- Unreal Engine 4.26 or 4.27.
-- Microsoft Visual Studio 2022 for Unreal Engine 4 C++ development.
+- Unreal Engine 5.4 (compatible with 5.5 and 5.6).
+- Microsoft Visual Studio 2022 for Unreal Engine 5 C++ development.
 - Microsoft Visual Studio Code for editing.
 
->__NOTE:__ If you need help with these setup steps, refer to the Unreal Engine 4 documentation, especially "Setting Up Visual Studio for Unreal Engine". The  was only tested with Visual Studio 2022 with Unreal Engine 4.27. The Unreal Engine sample __DOES NOT__ work with Ureal Engine 5.
+>__NOTE:__ If you need help with these setup steps, refer to the Unreal Engine 5 documentation, especially "Setting Up Visual Studio for Unreal Engine". The sample was tested with Visual Studio 2022 with Unreal Engine 5.4 and 5.6.
 
 ### AWS account requirements
 
@@ -227,7 +227,7 @@ An Unreal Engine sample project, [AmazonPollyMetaHuman](https://artifacts.kits.e
 6. Select the `Outputs` tab, and capture the values for `TextApiEndpointUrl`, and `RagApiEndpointUrl`.
 7. Download, the [AmazonPollyMetaHuman](https://artifacts.kits.eventoutfitters.aws.dev/industries/games/AmazonPollyMetaHuman.zip) zipped Unreal Engine project.
 8. Extract the `AmazonPollyMetaHuman` project folder to the `Unreal Projects` folder of the Unreal Engine development environment.
-9. Launch Unreal Engine 4.27, and open the `AmazonPollyMetaHuman` sample project.
+9. Launch Unreal Engine 5.4, and open the `AmazonPollyMetaHuman` sample project.
 10. Using the Unreal Editor, select `File` --> `Generate Visual Studio Code Project` to use VS Code for editing source code.
 11. Using the Unreal Editor, select `File` --> `Open Visual Studio Code` to open the project for code editing.
 12. In VS Code, open the `/Source/AmazonPollyMetaHuman/Private/Private/SpeechComponent.cpp` file for editing.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Overview
 
-Typical player interactions with NPCs are static, and require large teams of script writers to create static dialog content for each character, in each game, and each game version to ensure consistency with game lore. This Guidance helps game developers automate the process of creating a non-player character (NPC) for their games and associated infrastructure. It uses Unreal Engine, along with foundation models (FMs), for instance, the large language models (LLMs) Claude 2, and Llama 2, to improve NPC conversational skills. This leads to dynamic responses from the NPC that are unique to each player, adding to scripted dialogue. By using the Large Language Model Ops (LLMOps) methodology, this Guidance accelerates prototyping, and delivery time by continually integrating, and deploying the generative AI application, along with fine-tuning the LLMs. All while helping to ensure that the NPC has full access to a secure knowledge base of game lore, using retrieval-augmented generation (RAG).
+Typical player interactions with NPCs are static, and require large teams of script writers to create static dialog content for each character, in each game, and each game version to ensure consistency with game lore. This Guidance helps game developers automate the process of creating a non-player character (NPC) for their games and associated infrastructure. It uses Unreal Engine, along with foundation models (FMs), for instance, the large language models (LLMs) Claude 3.5, to improve NPC conversational skills. This leads to dynamic responses from the NPC that are unique to each player, adding to scripted dialogue. By using the Large Language Model Ops (LLMOps) methodology, this Guidance accelerates prototyping, and delivery time by continually integrating, and deploying the generative AI application, along with fine-tuning the LLMs. All while helping to ensure that the NPC has full access to a secure knowledge base of game lore, using retrieval-augmented generation (RAG).
 
 ___If you're looking for quick and easy step by step guide to get started, check out the Workshop -  [Operationalize Generative AI Applications using LLMOps](https://catalog.us-east-1.prod.workshops.aws/workshops/90992473-01e8-42d6-834f-9baf866a9057/en-US).___
 
@@ -83,10 +83,10 @@ This deployment requires that you have an existing [Amazon SageMaker Domain](htt
 >__NOTE:__ See the [Quick onboard to Amazon SageMaker Domain](https://docs.aws.amazon.com/sagemaker/latest/dg/onboard-quick-start.html) section of the __Amazon SageMaker Developer Guide__ for more information on how to configure an __Amazon SageMaker Domain__ in your AWS account. 
 
 - Bedrock Model Access
-    - Anthropic Claude
+    - Anthropic Claude 3.5 Haiku
     - Amazon Titan Embeddings G1 - Text
 
->__NOTE:__ AWS accounts do not have access to models by default, see the [Model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html) section of the __Amazon Bedrock User Guide__ to request access to the `Claude v2`, and `Titan Embeddings` foundation models.
+>__NOTE:__ Bedrock foundation models are now automatically enabled when first invoked. For Anthropic Claude models, some first-time users may need to submit use case details before accessing the model. See the [Model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html) section of the __Amazon Bedrock User Guide__ for more information.
 
 ### aws cdk bootstrap
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Overview
 
-Typical player interactions with NPCs are static, and require large teams of script writers to create static dialog content for each character, in each game, and each game version to ensure consistency with game lore. This Guidance helps game developers automate the process of creating a non-player character (NPC) for their games and associated infrastructure. It uses Unreal Engine, along with foundation models (FMs), for instance, the large language models (LLMs) Claude 3.5, to improve NPC conversational skills. This leads to dynamic responses from the NPC that are unique to each player, adding to scripted dialogue. By using the Large Language Model Ops (LLMOps) methodology, this Guidance accelerates prototyping, and delivery time by continually integrating, and deploying the generative AI application, along with fine-tuning the LLMs. All while helping to ensure that the NPC has full access to a secure knowledge base of game lore, using retrieval-augmented generation (RAG).
+Typical player interactions with NPCs are static, and require large teams of script writers to create static dialog content for each character, in each game, and each game version to ensure consistency with game lore. This Guidance helps game developers automate the process of creating a non-player character (NPC) for their games and associated infrastructure. It uses Unreal Engine, along with foundation models (FMs), for instance, the large language models (LLMs) Claude 3.5, to improve NPC conversational skills. The solution integrates Amazon Polly to convert NPC responses into speech with viseme data for realistic lip-sync animation in MetaHuman characters. This leads to dynamic responses from the NPC that are unique to each player, adding to scripted dialogue. By using the Large Language Model Ops (LLMOps) methodology, this Guidance accelerates prototyping, and delivery time by continually integrating, and deploying the generative AI application, along with fine-tuning the LLMs. All while helping to ensure that the NPC has full access to a secure knowledge base of game lore, using retrieval-augmented generation (RAG).
 
 ___If you're looking for quick and easy step by step guide to get started, check out the Workshop -  [Operationalize Generative AI Applications using LLMOps](https://catalog.us-east-1.prod.workshops.aws/workshops/90992473-01e8-42d6-834f-9baf866a9057/en-US).___
 
@@ -32,7 +32,7 @@ ___If you're looking for quick and easy step by step guide to get started, check
 
 ### Cost
 
-_You are responsible for the cost of the AWS services used while running this Guidance. As of November 2025, the cost for running this Guidance with the default settings in the `us-west-2` (Oregon) AWS Region is approximately $275 per month for processing 100 requests._
+_You are responsible for the cost of the AWS services used while running this Guidance. As of November 2025, the cost for running this Guidance with the default settings in the `us-east-1` (N. Virginia) AWS Region is approximately $275 per month for processing 100 requests._
 
 For example, the following table shows a break-down of approximate costs _(per month)_ to process 100 requests, using an **Amazon OpenSearch Service** vector database for RAG:
 
@@ -201,13 +201,15 @@ Once the `QA` stage of the pipeline is complete, and the `SystemTest` stage acti
 
 ### Hydrating the vector store
 
+>__NOTE:__ This guidance uses 3 data nodes without dedicated master nodes, following AWS best practices for clusters with fewer than 10 nodes. Master election is handled automatically by the data nodes. For production deployments with 10+ nodes or heavy write workloads, consider adding dedicated master nodes.
+
 The following steps will demonstrate how to hydrate the **Amazon OpenSearch Service** vector database for RAG:
 
 1. Download a copy of [Treasure Island by Robert Louis Stevenson](https://www.gutenberg.org/ebooks/120.txt.utf-8) to test vector store hydration and RAG.
 2. Using the AWS Console, navigate to Amazon S3 service, and select the bucket with the following format, `<WORKLOAD NAME>-qa-<REGION>-<ACCOUNT NUMBER>`. For example,  `ada-qa-us-east-1-123456789`.
 3. Upload the Treasure Island File, by clicking on the upload button, and selecting the file `pg120.txt` file. This will trigger the **AWS Lambda** function that starts a an **Amazon SageMaker Processing Job** to hydrate the **Amazon OpenSearch Service** database.
 3. Open the [SageMaker](https://console.aws.amazon.com/sagemaker) console. Using the navigation panel on the left-hand side, expand the `Processing` option, and then select `Processing jobs`. You'll see a processing job has been started, for example `Ada-RAG-Ingest-01-21-20-13-20`. This jobs executes the process of chunking the ebook data, converting it to embeddings, and hydrating the database. 
-4. Clink on the running processing job to view its configuration. Under the `Monitoring`, click the `View logs` link to see see the processing logs for your job in **Amazon CloudWatch**. After roughly 5 minutes, the log stream becomes available, and after clicking on the log stream, you will see that each line of the log output represents the successful processing of a chunk of the text inserted into the vector store. For example:
+4. Click on the running processing job to view its configuration. Under the `Monitoring`, click the `View logs` link to see see the processing logs for your job in **Amazon CloudWatch**. After roughly 5 minutes, the log stream becomes available, and after clicking on the log stream, you will see that each line of the log output represents the successful processing of a chunk of the text inserted into the vector store. For example:
 
 <p align="center">
     <img src="assets/images/sagemaker_job_log.png" alt="SageMaker Log" style="width: 33em;" />

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Before deploying the guidance code, ensure that the following required tools hav
 
 - Unreal Engine 5.4 (compatible with 5.5 and 5.6).
 - Microsoft Visual Studio 2022 for Unreal Engine 5 C++ development.
-- Microsoft Visual Studio Code for editing.
 
 >__NOTE:__ If you need help with these setup steps, refer to the Unreal Engine 5 documentation, especially "Setting Up Visual Studio for Unreal Engine". The sample was tested with Visual Studio 2022 with Unreal Engine 5.4 and 5.6.
 
@@ -175,6 +174,8 @@ All features for this guidance are only available in the _US East (N. Virginia)_
 ## Deployment Validation
 
 To verify a successful deployment of this guidance, open [CloudFormation](https://console.aws.amazon.com/cloudformation/home) console, and verify the status of the stack infrastructure stack is `CREATE_COMPLETE`. For example, if your `WORKLOAD_NAME` parameter is `Ada`, CloudFormation will reflect that the `Ada-Toolchain` stack has a `CREATE_COMPLETE` status.
+
+>__NOTE:__ If upgrading from a previous version of this guidance, the OpenSearch cluster configuration has changed (removed dedicated master nodes). You will need to delete the existing QA/PROD stacks before redeploying. See the [Cleanup](#cleanup) section for instructions.
 
 ## Running the Guidance
 

--- a/README.md
+++ b/README.md
@@ -221,38 +221,35 @@ The following steps will demonstrate how to hydrate the **Amazon OpenSearch Serv
 
 An Unreal Engine sample project, [AmazonPollyMetaHuman](https://artifacts.kits.eventoutfitters.aws.dev/industries/games/AmazonPollyMetaHuman.zip), has been provided for download. This sample [MetaHuman digital character](https://www.unrealengine.com/en-US/digital-humans) can be used to showcase dynamic NPC dialog. Use the following steps to integrate the sample MetaHuman with the deployed guidance infrastructure:
 
-1. Open the [IAM console](https://console.aws.amazon.com/iam/) in your AWS account, [create a new IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html).
-2. Assign the `AmazonPollyReadOnlyAccess` policy to the newly created user.
-3. Create a new [access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey) for the user. 
-4. [Install and configure](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) the AWS CLI on the computer that will run the Unreal Engine sample project to use the `Access Key ID`, and `Secret Access Key` values for the IA M user you created previously.
-5. Using the [CloudFormation console](https://console.aws.amazon.com/cloudformation/home), click the deployed `QA` stack. For example, if your `WORKLOAD_NAME` parameter is `Ada`, CloudFormation will reflect that `Ada-QA` as the deployed `QA` stack.
-6. Select the `Outputs` tab, and capture the values for `TextApiEndpointUrl`, and `RagApiEndpointUrl`.
-7. Download, the [AmazonPollyMetaHuman](https://artifacts.kits.eventoutfitters.aws.dev/industries/games/AmazonPollyMetaHuman.zip) zipped Unreal Engine project.
-8. Extract the `AmazonPollyMetaHuman` project folder to the `Unreal Projects` folder of the Unreal Engine development environment.
-9. Launch Unreal Engine 5.4, and open the `AmazonPollyMetaHuman` sample project.
-10. Using the Unreal Editor, select `File` --> `Generate Visual Studio Code Project` to use VS Code for editing source code.
-11. Using the Unreal Editor, select `File` --> `Open Visual Studio Code` to open the project for code editing.
-12. In VS Code, open the `/Source/AmazonPollyMetaHuman/Private/Private/SpeechComponent.cpp` file for editing.
-13. Navigate to the following code section, and replace the `ComboboxUri` variables with the `TextApiEndpointUrl`, and `RagApiEndpointUrl` CloudFormation outputs.
+1. Using the [CloudFormation console](https://console.aws.amazon.com/cloudformation/home), click the deployed `QA` stack. For example, if your `WORKLOAD_NAME` parameter is `Ada`, CloudFormation will reflect that `Ada-QA` as the deployed `QA` stack.
+2. Select the `Outputs` tab, and capture the values for `TextApiEndpointUrl`, and `RagApiEndpointUrl`.
+3. Download the [AmazonPollyMetaHuman](https://artifacts.kits.eventoutfitters.aws.dev/industries/games/AmazonPollyMetaHuman.zip) zipped Unreal Engine project.
+4. Extract the `AmazonPollyMetaHuman` project folder.
+5. Right-click on the `AmazonPollyMetaHuman.uproject` file and select `Generate Visual Studio project files`.
+6. Open the `AmazonPollyMetaHuman.sln` file in Microsoft Visual Studio 2022.
+7. In Visual Studio, navigate to `Source/AmazonPollyMetaHuman/Private/SpeechComponent.cpp` and open it for editing.
+8. Locate the `CallAPI` function and update the placeholder URLs with your API endpoints from CloudFormation:
     ```cpp
-        void USpeechComponent::CallAPI(const FString Text, const FString Uri)
+    void USpeechComponent::CallAPI(const FString Text, const FString Uri)
+    {
+        FString ComboBoxUri = "";
+        FHttpRequestRef Request = FHttpModule::Get().CreateRequest();
+        UE_LOG(LogPollyMsg, Display, TEXT("%s"), *Uri);
+        if(Uri == "Regular LLM")
         {
-            FString ComboBoxUri = "";
-            FHttpRequestRef Request = FHttpModule::Get().CreateRequest();
-            UE_LOG(LogPollyMsg, Display, TEXT("%s"), *Uri);
-            if(Uri == "Regular LLM")
-            {
-                UE_LOG(LogPollyMsg, Display, TEXT("If Regular LLM"));
-                ComboBoxUri = "<ADD `TextApiEndpointUrl` VALUE FROM GUIDANCE DEPLOYMENT>";
-            } else {
-                UE_LOG(LogPollyMsg, Display, TEXT("If Else"));
-                
-                ComboBoxUri = "<ADD `RagApiEndpointUrl` VALUE FROM GUIDANCE DEPLOYMENT>";
-            }
+            UE_LOG(LogPollyMsg, Display, TEXT("If Regular LLM"));
+            ComboBoxUri = "<ADD TextApiEndpointUrl VALUE FROM CLOUDFORMATION>";
+        } else {
+            UE_LOG(LogPollyMsg, Display, TEXT("If Else"));
+            
+            ComboBoxUri = "<ADD RagApiEndpointUrl VALUE FROM CLOUDFORMATION>";
+        }
     ```
-14. Save the `SpeechComponent.cpp` file, and close VS Code.
-15. Using the Unreal Editor, click the `Compile` button to recompile the C++ code.
-16. Once the updated code has been compiled, click the `Play` button to interact with the ___Ada___ NPC.
+9. Save the file.
+10. In Visual Studio, select `Build` --> `Build Solution` to compile the project.
+11. Once the build completes successfully, close Visual Studio.
+12. Open the `AmazonPollyMetaHuman.uproject` file to launch Unreal Engine.
+13. Click the `Play` button to interact with the Ada NPC.
 
 >__NOTE:__ Review the detailed [installation guide](assets/docs/metahuman_windows.md) for Windows 2022 for more information on installing, and configuring both Unreal Engine, and the sample project.
 

--- a/assets/docs/metahuman_windows.md
+++ b/assets/docs/metahuman_windows.md
@@ -1,9 +1,9 @@
-# Install Unreal Engine 4.27.2 on Windows 2022
+# Install Unreal Engine 5.4 on Windows 2022
 
 ## Prerequisites
 
 1. Ensure you have ~50GB of available disk space for the installation.
-2. Download and run the ___Visual Studio 2022 (Community Edition)___ installer. See [Setting Up Visual Studio for Unreal Engine](https://docs.unrealengine.com/4.26/en-US/ProductionPipelines/DevelopmentSetup/VisualStudioSetup/) for more information.
+2. Download and run the ___Visual Studio 2022 (Community Edition)___ installer. See [Setting Up Visual Studio for Unreal Engine](https://docs.unrealengine.com/5.4/en-US/setting-up-visual-studio-development-environment-for-cplusplus-projects-in-unreal-engine/) for more information.
     - Select ___Game development with C++___ under ___Workloads___.
     - Under ___Optional___, make sure the checkbox for ___Unreal Engine installer___ is checked to enable it.
 3. Download and install [Visual Studio Code](https://code.visualstudio.com/download).
@@ -11,12 +11,12 @@
     - Configure the AWS CLI credentials to use the Access Key ID and the Secret Access Key for the user.
     - Test access with the following command: ```aws polly describe-voices```, using the ___Command Prompt___.
 
-## Unreal Engine 4.27.2 Installation
+## Unreal Engine 5.4 Installation
 
 1. Run the ___Epic Games Launcher___, by double-clicking on the desktop icon.
 2. Sign into your ___Epic Games___ account. 
 3. Select ___Unreal Engine___ in the left-hand navigation panel, and click on the ___Library__ tab. 
-4. Click the ___ENGINE VERSIONS___ "plus" option, and select ___4.27.2___ from the version drop-down.
+4. Click the ___ENGINE VERSIONS___ "plus" option, and select ___5.4___ from the version drop-down.
 5. Click the ___Install___ button.
 6. Accept the default installation locations, and click ___Install___.
 

--- a/assets/docs/metahuman_windows.md
+++ b/assets/docs/metahuman_windows.md
@@ -6,10 +6,6 @@
 2. Download and run the ___Visual Studio 2022 (Community Edition)___ installer. See [Setting Up Visual Studio for Unreal Engine](https://docs.unrealengine.com/5.4/en-US/setting-up-visual-studio-development-environment-for-cplusplus-projects-in-unreal-engine/) for more information.
     - Select ___Game development with C++___ under ___Workloads___.
     - Under ___Optional___, make sure the checkbox for ___Unreal Engine installer___ is checked to enable it.
-3. Download and install [Visual Studio Code](https://code.visualstudio.com/download).
-4. Download and install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
-    - Configure the AWS CLI credentials to use the Access Key ID and the Secret Access Key for the user.
-    - Test access with the following command: ```aws polly describe-voices```, using the ___Command Prompt___.
 
 ## Unreal Engine 5.4 Installation
 
@@ -20,37 +16,32 @@
 5. Click the ___Install___ button.
 6. Accept the default installation locations, and click ___Install___.
 
-## Open the MetaHuman Project 
+## Configure the MetaHuman Project
 
 1. Download the [MetaHuman](https://artifacts.kits.eventoutfitters.aws.dev/industries/games/AmazonPollyMetaHuman.zip) sample project.
-2. Extract the `AmazonPollyMetaHuman` folder, and copy it to the `Documents\Unreal Projects` folder.
-3. Using the ___Unreal Games Launcher___, click on the ___Launch___ button to start the ___Unreal Editor___.
-4. When prompted to ___Select or Create New Project___, click the ___More___ button in the top right-hand corner.
-5. Click the ___Browse...___ button and navigate to the `Documents\Unreal Projects\AmazonPollyMetaHuman` folder, and double-click on the `AmazonPollyMetaHuman.uproject` file.
-6. When prompted, click __Yes__ to rebuild the `AmazonPollyMetaHuman` modules.
-
-## Configure the Backend Integration
-
-1. Using the Unreal Editor, select `File` --> `Generate Visual Studio Code Project` to use VS Code for editing source code.
-2. Using the Unreal Editor, select `File` --> `Open Visual Studio Code` to open the project for code editing.
-3. In VS Code, open the `/Source/AmazonPollyMetaHuman/Private/Private/SpeechComponent.cpp` file for editing.
-4. Navigate to the following code section, and replace the `ComboboxUri` variables with the `TextApiEndpointUrl`, and `RagApiEndpointUrl` CloudFormation outputs.
+2. Extract the `AmazonPollyMetaHuman` folder.
+3. Right-click on the `AmazonPollyMetaHuman.uproject` file and select `Generate Visual Studio project files`.
+4. Open the `AmazonPollyMetaHuman.sln` file in Microsoft Visual Studio 2022.
+5. In Visual Studio, navigate to `Source/AmazonPollyMetaHuman/Private/SpeechComponent.cpp` and open it for editing.
+6. Locate the `CallAPI` function and update the placeholder URLs with your API endpoints from CloudFormation:
     ```cpp
-        void USpeechComponent::CallAPI(const FString Text, const FString Uri)
+    void USpeechComponent::CallAPI(const FString Text, const FString Uri)
+    {
+        FString ComboBoxUri = "";
+        FHttpRequestRef Request = FHttpModule::Get().CreateRequest();
+        UE_LOG(LogPollyMsg, Display, TEXT("%s"), *Uri);
+        if(Uri == "Regular LLM")
         {
-            FString ComboBoxUri = "";
-            FHttpRequestRef Request = FHttpModule::Get().CreateRequest();
-            UE_LOG(LogPollyMsg, Display, TEXT("%s"), *Uri);
-            if(Uri == "Regular LLM")
-            {
-                UE_LOG(LogPollyMsg, Display, TEXT("If Regular LLM"));
-                ComboBoxUri = "<ADD `TextApiEndpointUrl` VALUE FROM GUIDANCE DEPLOYMENT>";
-            } else {
-                UE_LOG(LogPollyMsg, Display, TEXT("If Else"));
-                
-                ComboBoxUri = "<ADD `RagApiEndpointUrl` VALUE FROM GUIDANCE DEPLOYMENT>";
-            }
+            UE_LOG(LogPollyMsg, Display, TEXT("If Regular LLM"));
+            ComboBoxUri = "<ADD TextApiEndpointUrl VALUE FROM CLOUDFORMATION>";
+        } else {
+            UE_LOG(LogPollyMsg, Display, TEXT("If Else"));
+            
+            ComboBoxUri = "<ADD RagApiEndpointUrl VALUE FROM CLOUDFORMATION>";
+        }
     ```
-5. Save the `SpeechComponent.cpp` file, and close VS Code.
-6. Using the Unreal Editor, click the `Compile` button to recompile the C++ code.
-7. Once the updated code has been compiled, click the `Play` button to interact with the ___Ada___ NPC.
+7. Save the file.
+8. In Visual Studio, select `Build` --> `Build Solution` to compile the project.
+9. Once the build completes successfully, close Visual Studio.
+10. Open the `AmazonPollyMetaHuman.uproject` file to launch Unreal Engine.
+11. Click the `Play` button to interact with the Ada NPC.

--- a/cdk.json
+++ b/cdk.json
@@ -61,7 +61,7 @@
     "@aws-cdk/aws-cloudwatch-actions:changeLambdaPermissionLogicalIdForLambdaAction": true,
     "toolchain-context": {
       "cdk-version": "2.178.2",
-      "bedrock-text-model-id": "anthropic.claude-v2",
+      "bedrock-text-model-id": "anthropic.claude-3-5-haiku-20241022-v2:0",
       "bedrock-embedding-model-id": "amazon.titan-embed-text-v1",
       "embedding-index-name": "rag_embeddings",
       "tuning-epoch-count": "1",

--- a/cdk.json
+++ b/cdk.json
@@ -61,7 +61,7 @@
     "@aws-cdk/aws-cloudwatch-actions:changeLambdaPermissionLogicalIdForLambdaAction": true,
     "toolchain-context": {
       "cdk-version": "2.178.2",
-      "bedrock-text-model-id": "anthropic.claude-3-5-haiku-20241022-v2:0",
+      "bedrock-text-model-id": "anthropic.claude-3-5-haiku-20241022-v1:0",
       "bedrock-embedding-model-id": "amazon.titan-embed-text-v1",
       "embedding-index-name": "rag_embeddings",
       "tuning-epoch-count": "1",

--- a/components/rag_api/__init__.py
+++ b/components/rag_api/__init__.py
@@ -33,7 +33,8 @@ class RagApi(Construct):
                 statements=[
                     _iam.PolicyStatement(
                         actions=[
-                            "bedrock:InvokeModel"
+                            "bedrock:InvokeModel",
+                            "polly:SynthesizeSpeech"
                         ],
                         effect=_iam.Effect.ALLOW,
                         resources=["*"]

--- a/components/text_api/__init__.py
+++ b/components/text_api/__init__.py
@@ -33,7 +33,8 @@ class TextApi(Construct):
                 statements=[
                     _iam.PolicyStatement(
                         actions=[
-                            "bedrock:InvokeModel"
+                            "bedrock:InvokeModel",
+                            "polly:SynthesizeSpeech"
                         ],
                         effect=_iam.Effect.ALLOW,
                         resources=["*"]

--- a/components/text_api/runtime/index.py
+++ b/components/text_api/runtime/index.py
@@ -4,6 +4,7 @@
 import os
 import json
 import boto3
+import base64
 
 from typing import Dict
 from aws_lambda_powertools import Tracer
@@ -16,7 +17,7 @@ TEXT_MODEL_ID = os.environ["TEXT_MODEL_ID"]
 tracer = Tracer()
 logger = Logger()
 bedrock_client = boto3.client("bedrock-runtime")
-
+polly_client = boto3.client("polly")
 
 @tracer.capture_lambda_handler
 def lambda_handler(event, context): 
@@ -26,14 +27,25 @@ def lambda_handler(event, context):
     if validate_response:
         return validate_response
     question = body["question"]
+    # if the voice_id or voice_engine isn't specified, use default values
+    voice_id = body.get("voice_id", "Ruth")
+    voice_engine = body.get("voice_engine", "neural")
     logger.info(f"Question: {question}")
+    logger.info(f"Voice ID: {voice_id}")
+    logger.info(f"Voice Engine: {voice_engine}")
+
     response = get_prediction(question=question)
+
+    speech_info = synthesize_speech(text = response, 
+        voice_id = voice_id,
+        voice_engine = voice_engine)
+
     return build_response(
         {
-            "response": response
+            "response": response,
+            "speech_info" : speech_info
         }
     )
-
 
 def build_response(body: Dict) -> Dict:
     return {
@@ -55,7 +67,47 @@ def validate_inputs(body: Dict):
                 }
             )
 
-
+def synthesize_speech(text: str, voice_id: str, voice_engine: str):
+    # given text to synthesize along with the voice ID and engine, this will 
+    # get a buffer with the pcm in 1 channel 16-bit at 16k and then will
+    # get a buffer with json that has all of the viseme timings
+    speech_info = {}
+    
+    try:
+        sound_response = polly_client.synthesize_speech(
+            OutputFormat = "pcm",
+            Text = text,
+            VoiceId = voice_id,
+            Engine = voice_engine
+        )
+        audio_stream = sound_response["AudioStream"]
+        speech_info['sound_status'] = "ok"
+        speech_info['sound_response'] = base64.b64encode(audio_stream.read()).decode("utf-8")
+    except Exception as e:
+        speech_info['sound_status'] = "error"
+        exception_str = f"Audio Exception: {type(e).__name__} Message: {str(e)}"
+        speech_info['sound_error'] = exception_str
+        logger.info(exception_str)
+    
+    try:
+        viseme_response = polly_client.synthesize_speech(
+            OutputFormat = "json",
+            SpeechMarkTypes = ["viseme"],
+            Text = text,
+            VoiceId = voice_id,
+            Engine = voice_engine
+        )
+        viseme_strem = viseme_response["AudioStream"]
+        speech_info['viseme_status'] = "ok"
+        speech_info['viseme_response'] = base64.b64encode(viseme_strem.read()).decode("utf-8")
+    except Exception as e:
+        speech_info['viseme_status'] = "error"
+        exception_str = f"Viseme Exception: {type(e).__name__} Message: {str(e)}"
+        speech_info['viseme_error'] = exception_str
+        logger.info(exception_str)
+    
+    return speech_info
+    
 def get_prediction(question: str) -> str:
     prompt_template = f"""\n\nHuman: Your name is Ada, and you are a helpful assitant. Provide a concise answer to the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.
     

--- a/components/vector_store/__init__.py
+++ b/components/vector_store/__init__.py
@@ -64,7 +64,8 @@ class VectorStore(Construct):
             removal_policy=cdk.RemovalPolicy.DESTROY,
             capacity=_opensearch.CapacityConfig(
                 data_node_instance_type="r6g.large.search",
-                data_nodes=3
+                data_nodes=3,
+                multi_az_with_standby_enabled=False
             ),
             zone_awareness=_opensearch.ZoneAwarenessConfig(
                 availability_zone_count=3

--- a/components/vector_store/__init__.py
+++ b/components/vector_store/__init__.py
@@ -42,7 +42,7 @@ class VectorStore(Construct):
         self.search_domain = _opensearch.Domain(
             self,
             "OpenSearchDomain",
-            version=_opensearch.EngineVersion.OPENSEARCH_2_19,
+            version=_opensearch.EngineVersion.OPENSEARCH_2_15,
             ebs=_opensearch.EbsOptions(
                 volume_size=10,
                 volume_type=_ec2.EbsDeviceVolumeType.GP3

--- a/components/vector_store/__init__.py
+++ b/components/vector_store/__init__.py
@@ -42,9 +42,9 @@ class VectorStore(Construct):
         self.search_domain = _opensearch.Domain(
             self,
             "OpenSearchDomain",
-            version=_opensearch.EngineVersion.OPENSEARCH_2_9,
+            version=_opensearch.EngineVersion.OPENSEARCH_2_19,
             ebs=_opensearch.EbsOptions(
-                volume_size=20,
+                volume_size=10,
                 volume_type=_ec2.EbsDeviceVolumeType.GP3
             ),
             enforce_https=True,

--- a/components/vector_store/__init__.py
+++ b/components/vector_store/__init__.py
@@ -64,9 +64,7 @@ class VectorStore(Construct):
             removal_policy=cdk.RemovalPolicy.DESTROY,
             capacity=_opensearch.CapacityConfig(
                 data_node_instance_type="r6g.large.search",
-                data_nodes=3,
-                master_node_instance_type="r6g.large.search",
-                master_nodes=3
+                data_nodes=3
             ),
             zone_awareness=_opensearch.ZoneAwarenessConfig(
                 availability_zone_count=3


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

## Summary
This PR modernizes the guidance with significant performance improvements and cost reductions while updating to the latest versions of key components.

## Changes

### Model & Infrastructure Upgrades
- Upgrade from Claude v2 to Claude 3.5 Haiku (3x faster response times)
- Update OpenSearch from 2.9 to 2.15 (improved vector search performance)
- Remove dedicated master nodes following AWS best practices for small clusters

### Unreal Engine Updates
- Update from Unreal Engine 4.26/4.27 to 5.4 (compatible with 5.5 and 5.6)
- Simplify workflow: Visual Studio 2022 instead of VS Code
- Remove unnecessary IAM user and AWS CLI setup (APIs handle authentication)

### Cost Optimization
- Total monthly cost reduced from $590.59 to $272.90 (54% reduction)
- OpenSearch: $586.65 → $270.00
- Bedrock: $1.30 → $0.26

### Documentation Improvements
- Add Amazon Polly explanation in Overview
- Add OpenSearch architecture note explaining master node removal
- Update Bedrock model access information (auto-enabled)
- Add migration note for existing deployments
- Fix typos and ensure region consistency