### PR TITLE
Upgrade to Claude Haiku 4.5 and Titan Embeddings V2, fix invoke params and dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 			"dockerDashComposeVersion": "v1"
 		},
 		"ghcr.io/devcontainers-contrib/features/aws-cdk:2": {
-			"version": "2.126"
+			"version": "2.178.2"
 		}
 	},
 	"customizations": {

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Overview
 
-Typical player interactions with NPCs are static, and require large teams of script writers to create static dialog content for each character, in each game, and each game version to ensure consistency with game lore. This Guidance helps game developers automate the process of creating a non-player character (NPC) for their games and associated infrastructure. It uses Unreal Engine, along with foundation models (FMs), for instance, the large language models (LLMs) Claude 3.5, to improve NPC conversational skills. The solution integrates Amazon Polly to convert NPC responses into speech with viseme data for realistic lip-sync animation in MetaHuman characters. This leads to dynamic responses from the NPC that are unique to each player, adding to scripted dialogue. By using the Large Language Model Ops (LLMOps) methodology, this Guidance accelerates prototyping, and delivery time by continually integrating, and deploying the generative AI application, along with fine-tuning the LLMs. All while helping to ensure that the NPC has full access to a secure knowledge base of game lore, using retrieval-augmented generation (RAG).
+Typical player interactions with NPCs are static, and require large teams of script writers to create static dialog content for each character, in each game, and each game version to ensure consistency with game lore. This Guidance helps game developers automate the process of creating a non-player character (NPC) for their games and associated infrastructure. It uses Unreal Engine, along with foundation models (FMs), for instance, the large language models (LLMs) Claude Haiku 4.5, to improve NPC conversational skills. The solution integrates Amazon Polly to convert NPC responses into speech with viseme data for realistic lip-sync animation in MetaHuman characters. This leads to dynamic responses from the NPC that are unique to each player, adding to scripted dialogue. By using the Large Language Model Ops (LLMOps) methodology, this Guidance accelerates prototyping, and delivery time by continually integrating, and deploying the generative AI application, along with fine-tuning the LLMs. All while helping to ensure that the NPC has full access to a secure knowledge base of game lore, using retrieval-augmented generation (RAG).
 
 ___If you're looking for quick and easy step by step guide to get started, check out the Workshop -  [Operationalize Generative AI Applications using LLMOps](https://catalog.us-east-1.prod.workshops.aws/workshops/90992473-01e8-42d6-834f-9baf866a9057/en-US).___
 
@@ -32,19 +32,19 @@ ___If you're looking for quick and easy step by step guide to get started, check
 
 ### Cost
 
-_You are responsible for the cost of the AWS services used while running this Guidance. As of November 2025, the cost for running this Guidance with the default settings in the `us-east-1` (N. Virginia) AWS Region is approximately $275 per month for processing 100 requests._
+_You are responsible for the cost of the AWS services used while running this Guidance. As of April 2026, the cost for running this Guidance with the default settings in the `us-east-1` (N. Virginia) AWS Region is approximately $372 per month for processing 100 requests._
 
 For example, the following table shows a break-down of approximate costs _(per month)_ to process 100 requests, using an **Amazon OpenSearch Service** vector database for RAG:
 
 |     **Service**    | **Cost (per month)** |
 |:------------------:|:--------------------:|
-| OpenSearch Service | $270.00              |
+| OpenSearch Service | $369.00              |
 | SageMaker          | $1.43                |
 | S3                 | $0.67                |
 | CodeBuild          | $0.34                |
 | Secrets Manager    | $0.20                |
 | Bedrock            | $0.26                |
-|      **Total**     | **$272.90**          |
+|      **Total**     | **$371.90**          |
 
 
 ## Prerequisites
@@ -82,8 +82,8 @@ This deployment requires that you have an existing [Amazon SageMaker Domain](htt
 >__NOTE:__ See the [Quick onboard to Amazon SageMaker Domain](https://docs.aws.amazon.com/sagemaker/latest/dg/onboard-quick-start.html) section of the __Amazon SageMaker Developer Guide__ for more information on how to configure an __Amazon SageMaker Domain__ in your AWS account. 
 
 - Bedrock Model Access
-    - Anthropic Claude 3.5 Haiku
-    - Amazon Titan Embeddings G1 - Text
+    - Anthropic Claude Haiku 4.5
+    - Amazon Titan Text Embeddings V2
 
 >__NOTE:__ Bedrock foundation models are now automatically enabled when first invoked. For Anthropic Claude models, some first-time users may need to submit use case details before accessing the model. See the [Model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html) section of the __Amazon Bedrock User Guide__ for more information.
 

--- a/cdk.json
+++ b/cdk.json
@@ -61,8 +61,8 @@
     "@aws-cdk/aws-cloudwatch-actions:changeLambdaPermissionLogicalIdForLambdaAction": true,
     "toolchain-context": {
       "cdk-version": "2.178.2",
-      "bedrock-text-model-id": "anthropic.claude-3-5-haiku-20241022-v1:0",
-      "bedrock-embedding-model-id": "amazon.titan-embed-text-v1",
+      "bedrock-text-model-id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+      "bedrock-embedding-model-id": "amazon.titan-embed-text-v2:0",
       "embedding-index-name": "rag_embeddings",
       "tuning-epoch-count": "1",
       "tuning-batch-size": "1",

--- a/components/text_api/runtime/index.py
+++ b/components/text_api/runtime/index.py
@@ -122,8 +122,7 @@ def get_prediction(question: str) -> str:
                     }
                 ],
                 "temperature": 0.5,
-                "top_k": 250,
-                "top_p": 1
+                "top_k": 250
             }
         ),
         modelId=TEXT_MODEL_ID,

--- a/components/vector_store/scripts/data_ingest.py
+++ b/components/vector_store/scripts/data_ingest.py
@@ -68,7 +68,7 @@ def verify_index(endpoint: str, index: str, username: str, password: str) -> Any
             "properties": {
                 "vector_field": {  # k-NN vector field
                     "type": "knn_vector",
-                    "dimension": 1536,  # Dimension of the vector
+                    "dimension": 1024,  # Dimension of the vector
                     "similarity": "cosine"
                 },
                 "file_name": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 boto3>=1.34.16,<2.0
 aws-cdk-lib==2.178.2
 constructs>=10.0.0,<11.0.0
-sagemaker
+sagemaker>=2.0.0,<3.0.0
+pytz
 cdk-nag


### PR DESCRIPTION
*Description of changes:*
  - Update text model to us.anthropic.claude-haiku-4-5-20251001-v1:0 (geo inference)                                                                    
  - Update embedding model to amazon.titan-embed-text-v2:0 (1024 dimensions)                                                                            
  - Remove top_p parameter incompatible with Haiku 4.5                                                                                                  
  - Update OpenSearch vector index dimension from 1536 to 1024                                                                                          
  - Pin sagemaker<3 and add pytz to fix pipeline build                                                                                                  
  - Fix devcontainer CDK version mismatch                                                                                                               
  - Update README pricing and model references 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
